### PR TITLE
fix path.existsSync to fs.existsSync

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
             $ git clone git://github.com/caolvchong/tpl.git
             $ cd tpl
             $ vim ~/.bashrc
-            添加 alias tpl=~/tpl/src/tpl.bin.js，保存
+            添加 alias tpl=~/tpl/lib/tpl.bin.js，保存
     
 ##html模板语法
 ###变量

--- a/lib/tpl.bin.js
+++ b/lib/tpl.bin.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 var path = require('path');
+var fs = require('fs');
 var tpl = require('./tpl.core.js');
 
 var src, dest, fnName, charset = 'utf-8';
@@ -22,7 +23,7 @@ var util = {
         return version + '\n';
     },
     checkFileIsExists: function(src) {
-        return path.existsSync(path.resolve(src));
+        return fs.existsSync(path.resolve(src));
     },
     srcNotExists: function() {
         return 'error: the source file does not exist!\n';


### PR DESCRIPTION
path.existsSync is deprecated. as https://github.com/cthackers/adm-zip/issues/27

tpl failed to run in node v0.12 or v0.11.16, as I just updated my node.
